### PR TITLE
Make it runnable on single RV32I core

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ OBJS = \
 # riscv64-unknown-elf- or riscv64-linux-gnu-
 # perhaps in /opt/riscv/bin
 # FIXME: detect GNU toolchain installation
-TOOLPREFIX = riscv32-unknown-elf-
+TOOLPREFIX = riscv-none-embed-
 
 # Try to infer the correct TOOLPREFIX if not set
 ifndef TOOLPREFIX
@@ -75,6 +75,7 @@ endif
 
 LDFLAGS = -z max-page-size=4096
 
+# Need libgcc since no hardware support for mul/div
 LIBGCC = $(shell $(CC) --print-libgcc -march=rv32i -mabi=ilp32)
 
 $K/kernel: $(OBJS) $K/kernel.ld $U/initcode
@@ -156,8 +157,8 @@ GDBPORT = $(shell expr `id -u` % 5000 + 25000)
 QEMUGDB = $(shell if $(QEMU) -help | grep -q '^-gdb'; \
 	then echo "-gdb tcp::$(GDBPORT)"; \
 	else echo "-s -p $(GDBPORT)"; fi)
-# Only target for single core
 ifndef CPUS
+# TODO: target for single core since currently no SMP-safe spinlock implementation
 CPUS := 1
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -156,8 +156,9 @@ GDBPORT = $(shell expr `id -u` % 5000 + 25000)
 QEMUGDB = $(shell if $(QEMU) -help | grep -q '^-gdb'; \
 	then echo "-gdb tcp::$(GDBPORT)"; \
 	else echo "-s -p $(GDBPORT)"; fi)
+# Only target for single core
 ifndef CPUS
-CPUS := 3
+CPUS := 1
 endif
 
 QEMUOPTS = -machine virt -bios none -kernel $K/kernel -m 128M -smp $(CPUS) -nographic

--- a/kernel/entry.S
+++ b/kernel/entry.S
@@ -9,10 +9,11 @@ _entry:
         # with a 4096-byte stack per CPU.
         # sp = stack0 + (hartid * 4096)
         la sp, stack0
-        li a0, 1024*4
+        // li a0, 1024*4
 	csrr a1, mhartid
         addi a1, a1, 1
-        mul a0, a0, a1
+        // mul a0, a0, a1
+        slli a0, a1, 12
         add sp, sp, a0
 	# jump to start() in start.c
         call start

--- a/kernel/entry.S
+++ b/kernel/entry.S
@@ -9,10 +9,8 @@ _entry:
         # with a 4096-byte stack per CPU.
         # sp = stack0 + (hartid * 4096)
         la sp, stack0
-        // li a0, 1024*4
 	csrr a1, mhartid
         addi a1, a1, 1
-        // mul a0, a0, a1
         slli a0, a1, 12
         add sp, sp, a0
 	# jump to start() in start.c

--- a/kernel/spinlock.c
+++ b/kernel/spinlock.c
@@ -16,6 +16,20 @@ initlock(struct spinlock *lk, char *name)
   lk->cpu = 0;
 }
 
+uint
+lock_test_and_set(uint *lock, uint val)
+{
+    uint _lock = *lock;
+    if (!*lock) *lock = val;
+    return _lock;
+}
+
+void
+lock_release(uint *lock)
+{
+    *lock = 0;
+}
+
 // Acquire the lock.
 // Loops (spins) until the lock is acquired.
 void
@@ -29,7 +43,7 @@ acquire(struct spinlock *lk)
   //   a5 = 1
   //   s1 = &lk->locked
   //   amoswap.w.aq a5, a5, (s1)
-  while(__sync_lock_test_and_set(&lk->locked, 1) != 0)
+  while(lock_test_and_set(&lk->locked, 1) != 0)
     ;
 
   // Tell the C compiler and the processor to not move loads or stores
@@ -66,7 +80,7 @@ release(struct spinlock *lk)
   // On RISC-V, sync_lock_release turns into an atomic swap:
   //   s1 = &lk->locked
   //   amoswap.w zero, zero, (s1)
-  __sync_lock_release(&lk->locked);
+  lock_release(&lk->locked);
 
   pop_off();
 }

--- a/kernel/spinlock.c
+++ b/kernel/spinlock.c
@@ -8,6 +8,7 @@
 #include "proc.h"
 #include "defs.h"
 
+// FIXME: not SMP-safe operation
 void
 initlock(struct spinlock *lk, char *name)
 {
@@ -16,6 +17,7 @@ initlock(struct spinlock *lk, char *name)
   lk->cpu = 0;
 }
 
+// FIXME: not SMP-safe operation
 uint
 lock_test_and_set(uint *lock, uint val)
 {


### PR DESCRIPTION
Not works yet - we are still lack of spinlock implementation for rv32i:

```
riscv32-unknown-elf-ld: kernel/spinlock.o: in function `acquire':                              
/scratch/zhenw/xv6-riscv/kernel/spinlock.c:32: undefined reference to `__sync_lock_test_and_set
_4'                                                                                            
```